### PR TITLE
#100: functional getLocals with default (closes #100)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revenge",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "react component utilities",
   "main": "lib",
   "scripts": {

--- a/src/decorators/skinnable.js
+++ b/src/decorators/skinnable.js
@@ -1,6 +1,10 @@
 import t from 'tcomb';
 import isReactComponent from '../isReactComponent';
 
+const defaultGetLocals = function(props) {
+  return props;
+};
+
 export default function skinnable(template?: Function): Function {
 
   return function (Component) {
@@ -10,7 +14,7 @@ export default function skinnable(template?: Function): Function {
       t.assert(t.maybe(t.Func).is(template), `@skinnable decorator can only be configured with a function`);
       t.assert(isReactComponent(Component), `@skinnable decorator can only be applied to React.Component(s). Maybe did you type @skinnable instead of @skinnable()?`);
       t.assert(!t.Func.is(Component.prototype.render), `@skinnable decorator can only be applied to components not implementing the render() method. Please remove the render method of component ${name}`);
-      t.assert(t.Func.is(Component.prototype.getLocals), `@skinnable decorator requires a getLocals() method, add it to component ${name}`);
+      t.assert(t.maybe(t.Func).is(Component.prototype.getLocals), `@skinnable decorator requires getLocals() to be a function, check the component ${name}`);
       if (template) {
         t.assert(!t.Func.is(Component.prototype.template), `@skinnable decorator can only be applied to components not implementing the template(locals) method. Please remove the template method of component ${name}`);
       }
@@ -21,6 +25,10 @@ export default function skinnable(template?: Function): Function {
 
     if (template) {
       Component.prototype.template = template;
+    }
+
+    if (!Component.prototype.getLocals) {
+      Component.prototype.getLocals = defaultGetLocals;
     }
 
     Component.prototype.render = function () {

--- a/src/decorators/skinnable.js
+++ b/src/decorators/skinnable.js
@@ -24,7 +24,7 @@ export default function skinnable(template?: Function): Function {
     }
 
     Component.prototype.render = function () {
-      return this.template(this.getLocals());
+      return this.template(this.getLocals(this.props));
     };
   };
 }


### PR DESCRIPTION
Issue #100
## Test Plan
- `getLocals` is now `getLocals(props)`, i.e. component's props are passed as parameters.
- it should be omitted when one just wants to pass down props as they are. `getLocals() { return this.props; }` is the default;
### tests performed
- didn't break things in LoL after a quick test
