### PR TITLE
#104: @skinnable should cache locals (closes #104)

### DIFF
--- a/src/decorators/pure.js
+++ b/src/decorators/pure.js
@@ -10,13 +10,13 @@ export function shallowEqual(objA, objB, section, component) {
     return true;
   }
 
-  const displayName = component.constructor.name;
-  const rootNodeID = (component._reactInternalInstance || {})._rootNodeID;
+  const displayName = component && component.constructor.name;
+  const rootNodeID = component && (component._reactInternalInstance || {})._rootNodeID;
 
   if (!objA || typeof objA !== 'object') {
     // the opposite should never happen here, since we are using this as
     // `shallowEqual(prevProps, nextProps)` or `shallowEqual(prevState, nextState)`
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && section && component) {
       log(`component ${displayName} with rootNodeID ${rootNodeID} will re-render since object has no previous value`);
     }
     return false;
@@ -27,7 +27,7 @@ export function shallowEqual(objA, objB, section, component) {
   for (key in objA) {
     if (objA.hasOwnProperty(key) &&
         (!objB.hasOwnProperty(key) || objA[key] !== objB[key])) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && section && component) {
         log(`component ${displayName} with rootNodeID ${rootNodeID} will re-render since ${section} key ${key} is changed from `, objA[key], ' to ', objB[key]);
       }
       return false;
@@ -36,7 +36,7 @@ export function shallowEqual(objA, objB, section, component) {
   // Test for B's keys missing from A.
   for (key in objB) {
     if (objB.hasOwnProperty(key) && !objA.hasOwnProperty(key)) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (process.env.NODE_ENV !== 'production' && section && component) {
         log(`component ${displayName} with rootNodeID ${rootNodeID} will re-render since ${section} key ${key} with value `, objB[key], 'is new');
       }
       return false;

--- a/src/decorators/skinnable.js
+++ b/src/decorators/skinnable.js
@@ -33,14 +33,14 @@ export default function skinnable(template?: Function): Function {
       Component.prototype.getLocals = defaultGetLocals;
     }
 
-    const originalCWRP = Component.prototype.componentWillReceiveProps;
+    const originalCWU = Component.prototype.componentWillUpdate;
 
-    Component.prototype.componentWillReceiveProps = function(nextProps, nextState) {
-      this._refreshLocals = !shallowEqual(
-        omit(nextProps, 'children'),
-        omit(this.props, 'children')
+    Component.prototype.componentWillUpdate = function(nextProps, nextState) {
+      this._refreshLocals = (
+        !shallowEqual(omit(nextProps, 'children'), omit(this.props, 'children')) ||
+        !shallowEqual(nextState, this.state)
       );
-      originalCWRP && originalCWRP(nextProps, nextState);
+      originalCWU && originalCWU.call(this, nextProps, nextState);
     }
 
     Component.prototype.render = function () {

--- a/src/decorators/skinnable.js
+++ b/src/decorators/skinnable.js
@@ -1,5 +1,7 @@
 import t from 'tcomb';
+import omit from 'lodash/omit';
 import isReactComponent from '../isReactComponent';
+import { shallowEqual } from './pure';
 
 const defaultGetLocals = function(props) {
   return props;
@@ -31,8 +33,21 @@ export default function skinnable(template?: Function): Function {
       Component.prototype.getLocals = defaultGetLocals;
     }
 
+    const originalCWRP = Component.prototype.componentWillReceiveProps;
+
+    Component.prototype.componentWillReceiveProps = function(nextProps, nextState) {
+      this._refreshLocals = !shallowEqual(
+        omit(nextProps, 'children'),
+        omit(this.props, 'children')
+      );
+      originalCWRP && originalCWRP(nextProps, nextState);
+    }
+
     Component.prototype.render = function () {
-      return this.template(this.getLocals(this.props));
+      if (this._refreshLocals || !this._locals) {
+        this._locals = this.getLocals(this.props);
+      }
+      return this.template({ ...this._locals, children: this.props.children });
     };
   };
 }


### PR DESCRIPTION
Issue #104
## Test Plan
### tests performed

used in `FlexView` on QIA:
- app worked fine
- when only `children` changed (every polling) only `template` was called, not `getLocals`
  - app worked fine after re-render as well

This the changes I made to FlexView (apart from adding @skinnable of course)

``` jsx
getLocals() {
    window.FlexViewGetLocals = (window.FlexViewGetLocals || 0) + 1;
    console.log(`getLocals ${window.FlexViewGetLocals}`);
    return {
      ...omit(this.props, Object.keys(PropTypes)),
      className: this.getClasses(),
      style: this.getStyle()
    };
  };

  template({ className, style, children, ...locals}) {
    window.FlexViewTemplate = (window.FlexViewTemplate || 0) + 1;
    console.log(`template ${window.FlexViewTemplate}`);
    return (
      <div className={className} style={style} { ...locals }>
        {children}
      </div>
    );
  }
```

before:

``` jsx
render() {
    const className = this.getClasses();
    const style = this.getStyle();
    const props = omit(this.props, Object.keys(PropTypes));
    return (
      <div className={className} style={style} { ...props }>
        {this.props.children}
      </div>
    );
  }
```
### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.
> 
> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
